### PR TITLE
Service crawler error

### DIFF
--- a/service/internal/crawler/crawler.go
+++ b/service/internal/crawler/crawler.go
@@ -68,11 +68,6 @@ func VisitMil(entry *feed.Entry) (*feed.Entry, error) {
 
 func VisitMid(entry *feed.Entry) (*feed.Entry, error) {
 
-	// ожидаем перед запросом рандомно 1-5 секунд
-	n := 1 + rand.Intn(5)
-	d := time.Duration(n)
-	time.Sleep(d * time.Second)
-
 	c := colly.NewCollector()
 
 	//c.UserAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/111.0.0.0 Safari/537.36"
@@ -123,9 +118,9 @@ func VisitMid(entry *feed.Entry) (*feed.Entry, error) {
 		log.Printf("Mid announcements: %v", entry)
 	})
 
-	// ожидаем после запроса рандомно 1-5 секунд
-	n = 1 + rand.Intn(10)
-	d = time.Duration(n)
+	// ожидаем после запроса рандомно 1-10 секунд
+	n := 1 + rand.Intn(10)
+	d := time.Duration(n)
 	time.Sleep(d * time.Second)
 
 	//c.Visit("https://function.mil.ru:443/news_page/country/more.htm?id=12502939@egNews")

--- a/service/internal/crawler/crawler.go
+++ b/service/internal/crawler/crawler.go
@@ -84,9 +84,9 @@ func VisitMid(entry *feed.Entry) (*feed.Entry, error) {
 	// iterating over the list of industry card
 
 	// HTML elements
-	//c.Limit(&colly.LimitRule{
-	//	RandomDelay: 20 * time.Second,
-	//})
+	c.Limit(&colly.LimitRule{
+		RandomDelay: 10 * time.Second,
+	})
 
 	c.OnHTML("div.photo-content", func(e *colly.HTMLElement) {
 		log.Printf("Crawling Url %#v", entry.Url)

--- a/service/internal/crawler/crawler.go
+++ b/service/internal/crawler/crawler.go
@@ -10,7 +10,7 @@ import (
 	"time"
 )
 
-func VisitMil(entry *feed.Entry) *feed.Entry {
+func VisitMil(entry *feed.Entry) (*feed.Entry, error) {
 	c := colly.NewCollector()
 
 	c.UserAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/111.0.0.0 Safari/537.36"
@@ -60,12 +60,19 @@ func VisitMil(entry *feed.Entry) *feed.Entry {
 	err := c.Visit(entry.Url)
 	if err != nil {
 		log.Printf("Crawler Error: %v", err)
+		return nil, err
 	}
 
-	return entry
+	return entry, nil
 }
 
-func VisitMid(entry *feed.Entry) *feed.Entry {
+func VisitMid(entry *feed.Entry) (*feed.Entry, error) {
+
+	// ожидаем перед запросом рандомно 1-5 секунд
+	n := 1 + rand.Intn(5)
+	d := time.Duration(n)
+	time.Sleep(d * time.Second)
+
 	c := colly.NewCollector()
 
 	//c.UserAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/111.0.0.0 Safari/537.36"
@@ -116,15 +123,17 @@ func VisitMid(entry *feed.Entry) *feed.Entry {
 		log.Printf("Mid announcements: %v", entry)
 	})
 
-	n := 1 + rand.Intn(10)
-	d := time.Duration(n)
+	// ожидаем после запроса рандомно 1-5 секунд
+	n = 1 + rand.Intn(10)
+	d = time.Duration(n)
 	time.Sleep(d * time.Second)
 
 	//c.Visit("https://function.mil.ru:443/news_page/country/more.htm?id=12502939@egNews")
 	err := c.Visit(entry.Url)
 	if err != nil {
 		log.Printf("Crawler Error: %v", err)
+		return nil, err
 	}
 
-	return entry
+	return entry, nil
 }

--- a/service/internal/workerpool/task.go
+++ b/service/internal/workerpool/task.go
@@ -105,12 +105,24 @@ func process(workerID int, task *Task) {
 	task.Err = task.f(dbe)
 }
 
+// visitUrl вызывает crawler, который парсит контент по ссылке,
+// если crawler вернет ошибку, например в следствии read: connection reset by peer,
+// соединение с сайтом разорвалось, то функция возвращает запись entry без изменений,
+// если crawler вернул новую спарсенную entry (ce), то функция возвращает обновленную entry
 func visitUrl(e *feed.Entry) *feed.Entry {
 	switch e.ResourceID {
 	case 2:
-		e = crawler.VisitMid(e)
+		ce, err := crawler.VisitMid(e)
+		if err != nil {
+			return e
+		}
+		return ce
 	case 3:
-		e = crawler.VisitMil(e)
+		ce, err := crawler.VisitMil(e)
+		if err != nil {
+			return e
+		}
+		return ce
 	}
 
 	return e


### PR DESCRIPTION
Теперь crawler возвращает ошибку, если соединение было разорвано на обрабатываемом сайте.

Улучшена функция  visitUrl(), теперь функция возвращает ошибку
 visitUrl вызывает crawler, который парсит контент по ссылке,
 если crawler вернет ошибку, например в следствии read: connection reset by peer,
 соединение с сайтом разорвалось, то функция возвращает ошибку и происходит выход из обработки задачи, таким образом в следующий проход парсера, эта ссылка снова будет обработана и при отсутствии ошибки при обработке произойдет запись или обновление в БД. 
 если crawler вернул новую спарсенную entry, то функция возвращает обновленную entry и происходит запись или обновление в мантикоре.