### PR TITLE
Изменены адреса rss

### DIFF
--- a/cmd/rssfeed/main.go
+++ b/cmd/rssfeed/main.go
@@ -78,21 +78,21 @@ func generateFeed(ctx context.Context, entries *feed.Entries, duration time.Dura
 	// Фид для Кремля (ResourceID = 1)
 	kremlinFeed := &rssfeed.RssFeed{
 		Title:       "Новости Кремля",
-		Link:        "https://rss.feed.svodd.ru/kremlin-rss.xml",
+		Link:        "https://rss.feed.svodd.ru/kremlin.xml",
 		Description: "Новости с сайта Президента Российской Федерации",
 	}
 
 	// Фид для МИД (ResourceID = 2)
 	midFeed := &rssfeed.RssFeed{
 		Title:       "Новости МИД",
-		Link:        "https://rss.feed.svodd.ru/mid-rss.xml",
+		Link:        "https://rss.feed.svodd.ru/mid.xml",
 		Description: "Новости с сайта Министерства иностранных дел Российской Федерации",
 	}
 
 	// Фид для Минобороны (ResourceID = 3)
 	milFeed := &rssfeed.RssFeed{
 		Title:       "Новости Минобороны",
-		Link:        "https://rss.feed.svodd.ru/mil-rss.xml",
+		Link:        "https://rss.feed.svodd.ru/mil.xml",
 		Description: "Новости с сайта Министерства обороны Российской Федерации",
 	}
 
@@ -165,9 +165,9 @@ func generateFeed(ctx context.Context, entries *feed.Entries, duration time.Dura
 
 	// Сохраняем все фиды в файлы
 	saveFeedToFile(svoddFeed, "./static/rss.xml")
-	saveFeedToFile(kremlinFeed, "./static/kremlin-rss.xml")
-	saveFeedToFile(midFeed, "./static/mid-rss.xml")
-	saveFeedToFile(milFeed, "./static/mil-rss.xml")
+	saveFeedToFile(kremlinFeed, "./static/kremlin.xml")
+	saveFeedToFile(midFeed, "./static/mid.xml")
+	saveFeedToFile(milFeed, "./static/mil.xml")
 
 	log.Printf("🚩 Созданы RSS-фиды. Всего записей: %d\n", itemCount)
 }

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -43,17 +43,17 @@ func handlerRssFeed(w http.ResponseWriter, r *http.Request) {
 
 // Обработчик для RSS-фида Кремля
 func handlerKremlinFeed(w http.ResponseWriter, r *http.Request) {
-	serveRssFile(w, r, "./static/kremlin-rss.xml")
+	serveRssFile(w, r, "./static/kremlin.xml")
 }
 
 // Обработчик для RSS-фида МИД
 func handlerMidFeed(w http.ResponseWriter, r *http.Request) {
-	serveRssFile(w, r, "./static/mid-rss.xml")
+	serveRssFile(w, r, "./static/mid.xml")
 }
 
 // Обработчик для RSS-фида Минобороны
 func handlerMilFeed(w http.ResponseWriter, r *http.Request) {
-	serveRssFile(w, r, "./static/mil-rss.xml")
+	serveRssFile(w, r, "./static/mil.xml")
 }
 
 // serveRssFile читает файл и отправляет его как ответ
@@ -108,9 +108,9 @@ func main() {
 
 	// Обработчики для RSS-фидов
 	mux.Handle("/rss.xml", logMiddleware(http.HandlerFunc(handlerRssFeed), logger))
-	mux.Handle("/kremlin-rss.xml", logMiddleware(http.HandlerFunc(handlerKremlinFeed), logger))
-	mux.Handle("/mid-rss.xml", logMiddleware(http.HandlerFunc(handlerMidFeed), logger))
-	mux.Handle("/mil-rss.xml", logMiddleware(http.HandlerFunc(handlerMilFeed), logger))
+	mux.Handle("/kremlin.xml", logMiddleware(http.HandlerFunc(handlerKremlinFeed), logger))
+	mux.Handle("/mid.xml", logMiddleware(http.HandlerFunc(handlerMidFeed), logger))
+	mux.Handle("/mil.xml", logMiddleware(http.HandlerFunc(handlerMilFeed), logger))
 
 	// Обработчик для статических файлов
 	fs := http.FileServer(http.Dir("./static"))


### PR DESCRIPTION
Изменены адреса xml файлов каналов:
https://rss.feed.svodd.ru/rss.xml — общий
https://rss.feed.svodd.ru/kremlin.xml — Сайт Кремля
https://rss.feed.svodd.ru/mid.xml — Сайт МИД
https://rss.feed.svodd.ru/mil.xml — Сайт МО

Новости за последнюю неделю.