### PR TITLE
Добавлены метрики для службы парсера

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,4 +29,6 @@ COPY --from=builder /app/certs/ /etc/ssl/certs/
 COPY --from=builder /usr/share/zoneinfo /usr/share/zoneinfo
 ENV TZ=Europe/Moscow
 
+EXPOSE 8080
+
 CMD ["./feed-parser-service"]

--- a/cmd/indexer/kremlin/main.go
+++ b/cmd/indexer/kremlin/main.go
@@ -44,7 +44,7 @@ func main() {
 		for {
 			task := workerpool.NewTask(func(data interface{}) error {
 				return nil
-			}, <-ch, sp, entriesStore, cfg)
+			}, <-ch, sp, entriesStore, cfg, nil)
 			pool.AddTask(task)
 		}
 	}()

--- a/cmd/indexer/mid/main.go
+++ b/cmd/indexer/mid/main.go
@@ -43,7 +43,7 @@ func main() {
 		for {
 			task := workerpool.NewTask(func(data interface{}) error {
 				return nil
-			}, <-ch, sp, entriesStore, cfg)
+			}, <-ch, sp, entriesStore, cfg, nil)
 			pool.AddTask(task)
 		}
 	}()

--- a/cmd/indexer/mil/main.go
+++ b/cmd/indexer/mil/main.go
@@ -48,7 +48,7 @@ func main() {
 		for {
 			task := workerpool.NewTask(func(data interface{}) error {
 				return nil
-			}, <-ch, sp, entriesStore, cfg)
+			}, <-ch, sp, entriesStore, cfg, nil)
 			pool.AddTask(task)
 		}
 	}()

--- a/docker-compose-production.yml
+++ b/docker-compose-production.yml
@@ -3,6 +3,8 @@ services:
 
   service:
     image: ${REGISTRY}/feed-parser-service:${IMAGE_TAG}
+    ports:
+      - "8080:8080"
     networks:
       - feed-parser-net
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.9"
 services:
 
   registry:
@@ -10,25 +9,27 @@ services:
     networks:
       - feed-parser-net
 
-  # service:
-  #   image: ${REGISTRY:-localhost:5002}/feed-parser-service:main-1
-  #   build:
-  #     dockerfile: Dockerfile
-  #   restart: always
-  #   depends_on:
-  #     - registry
-  #   networks:
-  #     - feed-parser-net
-  #   volumes:
-  #     - config:/app/config
-  #   environment:
-  #     CONFIG_PATH: './config/local.yaml'
-  #     INDEX_NOW_KEY: 'HnZJOup42wLcpbCJTYA1d1V7afW76gXkjBf1gXQZ9jSO0KRWyH2zRH8qnlF75w3x'
-  #   command: './feed-parser-service'
-  #   deploy:
-  #     replicas: 1
-  #     restart_policy:
-  #       condition: on-failure
+  service:
+    image: ${REGISTRY:-localhost:5002}/feed-parser-service:main-1
+    build:
+      dockerfile: Dockerfile
+    ports:
+      - "8080:8080"
+    restart: always
+    depends_on:
+      - registry
+    networks:
+      - feed-parser-net
+    volumes:
+      - config:/app/config
+    environment:
+      CONFIG_PATH: './config/local.yaml'
+      INDEX_NOW_KEY: 'HnZJOup42wLcpbCJTYA1d1V7afW76gXkjBf1gXQZ9jSO0KRWyH2zRH8qnlF75w3x'
+    command: './feed-parser-service'
+    deploy:
+      replicas: 1
+      restart_policy:
+        condition: on-failure
 
   rssfeed:
     image: ${REGISTRY:-localhost:5002}/feed-static-generator:main-1

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -1,0 +1,55 @@
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type Metrics struct {
+	SuccessRequests  *prometheus.CounterVec
+	ErrorRequests    *prometheus.CounterVec
+	EntitiesInserted *prometheus.CounterVec
+	EntitiesUpdated  *prometheus.CounterVec
+}
+
+func NewMetrics() *Metrics {
+	return &Metrics{
+		SuccessRequests: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "rss_parser_success_requests_total",
+				Help: "Total number of successful requests.",
+			},
+			[]string{"url", "attempt"},
+		),
+		// Метрика для подсчета ошибок
+		ErrorRequests: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "rss_parser_error_requests_total",
+				Help: "Total number of failed requests.",
+			},
+			[]string{"url", "error_type", "attempt"}, // Метки для URL, типа ошибки и номера попытки
+		),
+		// Метрика для подсчета новых новостей, записанных в БД
+		EntitiesInserted: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "rss_parser_entities_inserted_total",
+				Help: "Total number of entities items inserted into the database.",
+			},
+			[]string{"url", "chunks"}, // Метка для URL, кол-во фрагментов
+		),
+		// Метрика для подсчета обновленных новостей в БД
+		EntitiesUpdated: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "rss_parser_entities_updated_total",
+				Help: "Total number of entities items updated in the database.",
+			},
+			[]string{"url", "chunks"}, // Метка для URL, кол-во фрагментов
+		),
+	}
+}
+
+func (m *Metrics) Register() {
+	prometheus.MustRegister(m.SuccessRequests)
+	prometheus.MustRegister(m.ErrorRequests)
+	prometheus.MustRegister(m.EntitiesInserted)
+	prometheus.MustRegister(m.EntitiesUpdated)
+}

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -5,3 +5,7 @@ scrape_configs:
   - job_name: 'rss_server'
     static_configs:
       - targets: ['host.docker.internal:8000']  # Адрес вашего сервера
+  
+  - job_name: 'feed-service-parser'
+    static_configs:
+      - targets: ['host.docker.internal:8080']  # Укажите IP и порт вашего сервиса


### PR DESCRIPTION
Prometheus будет собирать метрики, такие как:

`rss_parser_success_requests_total{url="http://example.com/rss"}` — количество успешных запросов для конкретного URL.

`rss_parser_error_requests_total{url="http://example.com/rss", error_type="connection reset by peer"}` — количество ошибок для конкретного URL и типа ошибки.

`rss_parser_request_duration_seconds{url="http://example.com/rss"}` — время выполнения запросов.

метрика `rss_parser_error_requests_total` с метками:

- `url`: URL RSS-ленты.
- `error_type`: Тип ошибки (например, connection reset by peer).
- `attempt`: Номер попытки (например, 1, 2, 3).

Пример запроса в Prometheus:

```promql
rate(rss_parser_error_requests_total{url="http://example.com/rss"}[1m])
```

Метрики:

- `rss_parser_success_requests_total{url="http://example.com/rss"}` — количество успешных запросов.
- `rss_parser_error_requests_total{url="http://example.com/rss", error_type="connection reset by peer", attempt="1"}` — количество ошибок с номером попытки.
- `rss_parser_news_inserted_total{url="http://example.com/rss"}` — количество новых новостей, записанных в БД.
- `rss_parser_news_updated_total{url="http://example.com/rss"}` — количество обновленных новостей в БД.
